### PR TITLE
use os path to get file name cross-platform

### DIFF
--- a/utils/data_loading.py
+++ b/utils/data_loading.py
@@ -58,7 +58,8 @@ class ClassificationDataset:
 
 def build_dataloaders(cfg):
     image_files = glob.glob(os.path.join(cfg.paths.dataset_dir, "*.png"))
-    original_targets = [x.split("/")[-1][:-4].replace("-copy", "") for x in image_files]
+    # get file label using os, fix windows double backslash issue
+    original_targets = [os.path.splitext(os.path.basename(x))[0] for x in image_files]
     targets = [[c for c in x] for x in original_targets]
     targets_flat = [c for clist in targets for c in clist]
     label_encoder = preprocessing.LabelEncoder()


### PR DESCRIPTION
fixes wrong captcha labels on Windows OS - when it's prefixed with dirname

before the fix (notice extra char `\\` in classes list and ground truth labels):
<img width="986" alt="Screenshot 2023-11-11 000717" src="https://github.com/GabrielDornelles/pytorch-ocr/assets/10671879/b1f4a01b-4751-4aa3-ae3f-961d5169d62c">

after the fix:
<img width="1014" alt="Screenshot 2023-11-11 000933" src="https://github.com/GabrielDornelles/pytorch-ocr/assets/10671879/cb7b5a5e-6d39-4542-8540-497603cafe9a">


tested on MacOS as well 👍 